### PR TITLE
Refs #1. Make copy of json in JsonObject ctor.

### DIFF
--- a/vertx-arango-http-client/src/main/java/com/emikra/vertx/arangodb/http/ArangoHttpClientOptions.java
+++ b/vertx-arango-http-client/src/main/java/com/emikra/vertx/arangodb/http/ArangoHttpClientOptions.java
@@ -13,11 +13,11 @@ public class ArangoHttpClientOptions {
     }
 
     public ArangoHttpClientOptions(ArangoHttpClientOptions options) {
-        this(options.toJson());
+        this(options.json);
     }
 
     public ArangoHttpClientOptions(JsonObject json) {
-        this.json = (json != null) ? json : new JsonObject();
+        this.json = (json != null) ? json.copy() : new JsonObject();
     }
 
     public JsonObject toJson() {


### PR DESCRIPTION
This is an additional fix related to issue #1 that I forget to include in the last pull request (like that issue actually states, `JsonObject.copy()` should be used in a data object's `JsonObject` constructor).

That's what this PR does.
